### PR TITLE
Fixed nowChecked cell display

### DIFF
--- a/DropDownMenu.swift
+++ b/DropDownMenu.swift
@@ -229,7 +229,7 @@ open class DropDownMenu : UIView, UITableViewDataSource, UITableViewDelegate, UI
 	}
 
 	open func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        var temCell = menuCells[indexPath.row]
+        let temCell = menuCells[indexPath.row]
         if (temCell.nowChecked){
             temCell.accessoryType = .checkmark
         }

--- a/DropDownMenu.swift
+++ b/DropDownMenu.swift
@@ -229,7 +229,11 @@ open class DropDownMenu : UIView, UITableViewDataSource, UITableViewDelegate, UI
 	}
 
 	open func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-		return menuCells[indexPath.row]
+        var temCell = menuCells[indexPath.row]
+        if (temCell.nowChecked){
+            temCell.accessoryType = .checkmark
+        }
+		return temCell
 	}
 	
 	open func tableView(_ tableView: UITableView, shouldHighlightRowAt indexPath: IndexPath) -> Bool {


### PR DESCRIPTION
There's a variable called `nowChecked` in the `DropDownMenuCell` but does nothing. I fixed this issue in this commit by checking `nowChecked` when putting `menuCells` onto `DropDownMenu`.